### PR TITLE
Extend --quiet flag

### DIFF
--- a/src/Cache.h
+++ b/src/Cache.h
@@ -40,7 +40,7 @@ public:
                  const std::string& sourcefile) const;
 
 private:
-    void invoke(const StringList& args) const;
+    void invoke(const StringList& args, bool quiet) const;
 
     std::string _ccache;
 };

--- a/src/CommandlineArguments.cpp
+++ b/src/CommandlineArguments.cpp
@@ -117,6 +117,9 @@ CommandlineArguments::CommandlineArguments(size_t argc, char const* const* argv)
         if (arg == "-E") {
             preprocess = true;
             remainingArgs.push_back(arg);
+        } else if (arg == "--quiet") {
+            quiet = true;
+            remainingArgs.push_back(arg);
         } else if (arg == "-c") {
             // drop
         } else if (arg == "-p" && i + 1 < argc) {

--- a/src/CommandlineArguments.h
+++ b/src/CommandlineArguments.h
@@ -48,6 +48,7 @@ public:
     StringList sources;
 
     bool preprocess = false;
+    bool quiet = false;
 
     std::string objectfile;
     std::string clangTidy;

--- a/test/clang-tidy/test.py
+++ b/test/clang-tidy/test.py
@@ -187,7 +187,9 @@ class TestClangTidy(unittest.TestCase):
         edited = contents.replace('<replace to edit>', 'testing')
         stats.zero()
         TestClangTidy.TESTED_FILE.write_text(edited)
-        self._run()
+        proc = self._run()
+        self.assertFalse(proc.stderr, f"Running with --quiet so nothing should end up in stderr: '{proc.stderr}'")
+        self.assertFalse(proc.stdout, f"Running with --quiet so nothing should end up in stdout: '{proc.stdout}'")
         self.assertEqual(1, stats.cacheable, msg=stats.print())
         self.assertEqual(0, stats.cache_hits, msg=stats.print())
 
@@ -260,6 +262,7 @@ class TestClangTidy(unittest.TestCase):
         TestClangTidy.TESTED_FILE.write_text(edited)
         proc = self._run(check=False)
         self.assertNotEqual(0, proc.returncode)
+        self.assertIn("error generated", proc.stderr, f"stderr: '{proc.stderr}'\nstdout: '{proc.stdout}'")
         self.assertIn("[clang-diagnostic-error]", proc.stdout, f"stderr: '{proc.stderr}'\nstdout: '{proc.stdout}'")
         self.assertEqual(1, stats.cacheable, msg=stats.print())
         self.assertEqual(0, stats.cache_hits, msg=stats.print())


### PR DESCRIPTION
Add handling of the --quiet flag so that output
is really quiet unless there is an error. This
is an extension to how clang-tidy itself is handling it which will still print a count of warnings generated but not printed.

This will close #1 