### PR TITLE
Fix compile errors with gcc-9

### DIFF
--- a/.gitea/workflows/checks.yaml
+++ b/.gitea/workflows/checks.yaml
@@ -20,6 +20,9 @@ jobs:
           - runner: ubuntu-2004-large
             compiler: clang
             generator: ninja
+          - runner: ubuntu-2004-large
+            compiler: gcc
+            generator: ninja
           - runner: windows-large
             compiler: msvc
             generator: ninja_64
@@ -38,7 +41,7 @@ jobs:
             submodules: 'true'
             fetch-depth: 0
       - name: Configure
-        run: bash ./build/generator.sh compiler=${{ matrix.compiler }} generator=${{ matrix.generator }} mode=release location=inside -DMZ_DO_CPPLINT_DIFF=OFF
+        run: bash ./build/generator.sh compiler=${{ matrix.compiler }} generator=${{ matrix.generator }} mode=release location=inside -DMZ_DO_CPPLINT_DIFF=OFF -DCONAN_BUILD_MISSING=ON
       - name: Build
         run: cmake --build -j 12 --preset ${{ matrix.compiler }}-${{ matrix.generator }}-release
       - name: Package

--- a/src/CommandlineArguments.cpp
+++ b/src/CommandlineArguments.cpp
@@ -114,7 +114,7 @@ CommandlineArguments::CommandlineArguments(size_t argc, char const* const* argv)
     remainingArgs.reserve(argc);
     self = argv[0];
 
-    for (int i = 1; i < argc; ++i) {
+    for (size_t i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         // parsed_args.tidyargs.append(arg)
         if (arg == "-h" || arg == "--help") {

--- a/test/unit/custom_main.cpp
+++ b/test/unit/custom_main.cpp
@@ -29,7 +29,7 @@
 int
 main(int argc, char* argv[])
 {
-    for (size_t i = 1; i + 1 < argc; ++i) {
+    for (int i = 1; i + 1 < argc; ++i) {
         if (0 == std::strcmp(argv[i], "--stderr")) {
             std::cerr << argv[++i] << std::flush;
         }


### PR DESCRIPTION
Resolves compile errors found with gcc and adds
tracking via the CI to prevent future regressions.

Closes #3 